### PR TITLE
Fixes for ShapeDetection

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpenCV/ShapeDetection.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpenCV/ShapeDetection.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.OpenCV;
 
+import com.acmerobotics.dashboard.config.Config;
+
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.Hardware.StatesHardware;
 import org.opencv.core.Core;
@@ -17,57 +19,82 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+@Config
 public class ShapeDetection extends OpenCvPipeline {
-    // Code Review: You should combine classes ShapeDetection and ShapeDetectionBlue, and have a
-    //              parameter (in constructor) for Red vs Blue. The only difference is the HSV
-    //              inRange values. (And the blur kernel size is slightly different)
-
     private Telemetry telemetry;
     private StatesHardware robot;
 
-    public double xMidVal;
-    public double xCentroid;
-    public boolean usingCentroid = true;
+    // To be deleted - kept only for old code
+    public double xMidVal = 0;
 
     Size targetSize = new Size(320, 240);
+    Size pipelineSize;
 
-    public ShapeDetection (Telemetry telemetry){
+    // Private things, allocate once
+    private static final int CV_8U3 = 16;
+    private static final int CV_8U4 = 24;
+    private static final Rect blankRect = new Rect(0,0,320,40);
+    private Mat threeChannelInputFrame = null;
+    private final Mat resizedInputFrame = new Mat(targetSize, CV_8U3);
+    private final Mat HSVImage = new Mat(targetSize, CV_8U3);
+    private final Mat croppedFrame = new Mat(targetSize, CV_8U3);
+    private final Mat croppedInputFrameRGB = new Mat(targetSize, CV_8U3);
+    private final Mat bwImage = new Mat(targetSize, CV_8U3);
+    private final Mat blurImg = new Mat(targetSize, CV_8U3);
+    private final Mat markup = new Mat(targetSize, CV_8U3);
+    private final Mat onlyFoundColorMask = new Mat(targetSize, CV_8U3);
+    private final Mat onlyFoundColorBlur = new Mat(targetSize, CV_8U3);
+    private final Mat outputFrameTop = new Mat(targetSize, CV_8U3);
+    private final Mat outputFrameBottom = new Mat(targetSize, CV_8U3);
+    private Mat outputFrame = null;
+    private Mat blankForOverlay = null;
+    private Mat zeros = new Mat();
+
+    // Public configuration
+    public static int boundingLine1 = 40;
+    public static int boundingLine2 = 200;
+    public static int blurSize = 19;
+    public static boolean doVisualization = true;
+    public static boolean usingCentroid = false;
+
+    public int spikeMark = 1; // TODO: Make this an Enum
+
+    public ShapeDetection (Telemetry telemetry) {
         this.telemetry = telemetry;
     }
+
     public ShapeDetection (Telemetry telemetry, StatesHardware robot){
         this.telemetry = telemetry;
         this.robot = robot;
     }
 
-    Rect rect;
-
-    public int boundingLine1 = 40;
-    public int boundingLine2 = 200;
-
-    public int spikeMark = 1;
-
-    public int blurSize = 19;
+    @Override
+    public void init(Mat firstFrame) {
+        pipelineSize = firstFrame.size();
+        threeChannelInputFrame = new Mat(pipelineSize, CV_8U3);
+        outputFrame = new Mat(pipelineSize, CV_8U3);
+    }
 
     public Mat processFrame(Mat inputFrameRGB) {
         if (inputFrameRGB == null) {
             return null;
         }
 
-        // telemetry.clearAll();
+        // Drop the alpha channel, if it exists
+        // Note: This is only really relevant for eocv-sim and use of jpg images
+        if (inputFrameRGB.type() == CV_8U4) {
+            Imgproc.cvtColor(inputFrameRGB, threeChannelInputFrame, Imgproc.COLOR_RGBA2RGB);
+        }
+        else {
+            inputFrameRGB.copyTo(threeChannelInputFrame);
+        }
 
         // Make sure the size is as expected
         // (In case we are using pixel-count thresholds)
-        Imgproc.resize(inputFrameRGB, inputFrameRGB, targetSize);
-
-        // Drop the alpha channel, if it exists
-        // Note: This is only really relevant for eocv-sim and use of jpg images
-        if (inputFrameRGB.type() == 24) { // CV_8U4 = 24
-            Imgproc.cvtColor(inputFrameRGB, inputFrameRGB, Imgproc.COLOR_RGBA2RGB);
-        }
+        Imgproc.resize(threeChannelInputFrame, resizedInputFrame, targetSize);
 
         //convert to HSV
-        Mat HSVImage = new Mat();
-        Imgproc.cvtColor(inputFrameRGB, HSVImage, Imgproc.COLOR_RGB2HSV);
+        Imgproc.cvtColor(resizedInputFrame, HSVImage, Imgproc.COLOR_RGB2HSV);
 
         // Instead of cropping, just black out the region of the frame that we want to ignore
         // Note: This is just a convenience for having an output frame to view, and not having
@@ -75,76 +102,25 @@ public class ShapeDetection extends OpenCvPipeline {
         //Rect cropRect = new Rect(0,40,320,200);
         //Mat croppedFrame = HSVImage.submat(cropRect);
         //Mat croppedInputFrameRGB = inputFrameRGB.submat(cropRect);
-        Rect blankRect = new Rect(0,0,320,40);
-        Mat croppedFrame = new Mat();
         HSVImage.copyTo(croppedFrame);
         Imgproc.rectangle(croppedFrame, blankRect, new Scalar(0,0,0), -1);
-        Mat croppedInputFrameRGB = new Mat();
-        inputFrameRGB.copyTo(croppedInputFrameRGB);
+        resizedInputFrame.copyTo(croppedInputFrameRGB);
         Imgproc.rectangle(croppedInputFrameRGB, blankRect, new Scalar(0,0,0), -1);
 
         // Find the pixels in the image that are our desired color (in HSV space)
-        Mat bwImage = new Mat();
         if(robot == null || robot.alliance == StatesHardware.Alliance.RED) {
                 Core.inRange(croppedFrame, new Scalar(160, 100, 100), new Scalar(180, 255, 250), bwImage);
         } else {
             Core.inRange(croppedFrame, new Scalar(80, 70, 90), new Scalar(140, 255, 255), bwImage);
         }
 
-        // Median blur this mask so that we can ignore the tape strips and any other noise
-        // Code Review: Note: blurImg is only used for contours... Also, this is a really big blur kernel.
-        Mat blurImg = new Mat();
+        // Median blur this mask so that we can ignore the tape strips and any other noise in the mask
         Imgproc.medianBlur(bwImage, blurImg, blurSize);
 
-        // Code Review: The boundingRect is calculated on bwImage. Should it be blurImage?
-        //              boundingRect will find _any_ non-zero pixel from inRange
-        rect = Imgproc.boundingRect(blurImg);
-
-        if(rect != null && !usingCentroid) {
-            telemetry.addData("x", rect.x);
-            telemetry.addData("y", rect.y);
-            telemetry.addData("xMid", this.xMid());
-            xMidVal = this.xMid();
-
-            if (xMidVal > boundingLine2) {
-                spikeMark = 3;
-            } else if (xMidVal > boundingLine1) {
-                spikeMark = 2;
-            } else {
-                spikeMark = 1;
-            }
-        }
+        // Get the bounding rectangle from the mask after median blur
+        Rect rect = Imgproc.boundingRect(blurImg);
 
         if(usingCentroid){
-            if (xCentroid > boundingLine2) {
-                spikeMark = 3;
-            } else if (xCentroid > boundingLine1) {
-                spikeMark = 2;
-            } else {
-                spikeMark = 1;
-            }
-        }
-        else {
-            //using contours...
-        }
-
-        // Do some visualization
-        // NOTE: This can be disabled for events!
-        boolean doVisualization = false;
-        Mat outputFrame = null;
-        if (doVisualization) {
-            // Make an image that will be marked up with lines and such
-            Mat markup = new Mat();
-            croppedInputFrameRGB.copyTo(markup);
-            Imgproc.rectangle(markup, rect, new Scalar(0, 255, 160), 2);
-
-            // Draw the threshold lines. These should be between the tape lines separating the spikes.
-            Imgproc.line(markup, new Point(boundingLine1, 0), new Point(boundingLine1, 240), new Scalar(0, 0, 0));
-            Imgproc.line(markup, new Point(boundingLine2, 0), new Point(boundingLine2, 240), new Scalar(0, 0, 0));
-
-            // Code Review: Contours are only found to draw them... Did you want to do something else
-            //              with the contours? Such as use the centroid of the largest region (moment 0)?
-            // For now, moved this down below the "only for visualization" line
             Mat eroded = new Mat();
             Mat strElement = Imgproc.getStructuringElement(Imgproc.CV_SHAPE_ELLIPSE, new Size(7, 7));
             Imgproc.erode(blurImg, eroded, strElement);
@@ -171,20 +147,55 @@ public class ShapeDetection extends OpenCvPipeline {
                 telemetry.addData("Sum Y", sumY);
                 telemetry.addData("Total Pixels", totalPixels);
 
-                xCentroid = averageX;
+                double xCentroid = averageX;
+
+                if (xCentroid > boundingLine2) {
+                    spikeMark = 3;
+                } else if (xCentroid > boundingLine1) {
+                    spikeMark = 2;
+                } else {
+                    spikeMark = 1;
+                }
             } else {
                 telemetry.addLine("No Contours Found");
                 return inputFrameRGB;
             }
+        }
+        else {
+            // Determine the middle of the bounding rect, in x dimension
+            telemetry.addData("x", rect.x);
+            telemetry.addData("y", rect.y);
+            xMidVal = rect.x + (rect.width / 2.0);
+            telemetry.addData("X Mid", xMidVal);
+
+            // Classify the spikemark based on the x mid value
+            if (xMidVal > boundingLine2) {
+                spikeMark = 3;
+            } else if (xMidVal > boundingLine1) {
+                spikeMark = 2;
+            } else {
+                spikeMark = 1;
+            }
+            telemetry.addData("Spike Mark", spikeMark);
+        }
+
+        // Do some visualization
+        // NOTE: This can be disabled for events!
+        if (doVisualization) {
+            // Make an image that will be marked up with lines and such
+            croppedInputFrameRGB.copyTo(markup);
+            Imgproc.rectangle(markup, rect, new Scalar(0, 255, 160), 2);
+
+            // Draw the threshold lines. These should be between the tape lines separating the spikes.
+            Imgproc.line(markup, new Point(boundingLine1, 0), new Point(boundingLine1, 240), new Scalar(0, 0, 0));
+            Imgproc.line(markup, new Point(boundingLine2, 0), new Point(boundingLine2, 240), new Scalar(0, 0, 0));
 
             // Make an image showing what the color mask output finds
-            Mat onlyFoundColorMask = new Mat();
             Imgproc.cvtColor(bwImage, bwImage, Imgproc.COLOR_GRAY2RGB);
             Core.bitwise_and(bwImage, croppedInputFrameRGB, onlyFoundColorMask);
 
             // Make an image showing what the blur does to the color mask
             // Note: This has to be after findContours (as-is, without gray2rgb into another mat...)
-            Mat onlyFoundColorBlur = new Mat();
             Imgproc.cvtColor(blurImg, blurImg, Imgproc.COLOR_GRAY2RGB);
             Core.bitwise_and(blurImg, croppedInputFrameRGB, onlyFoundColorBlur);
 
@@ -195,41 +206,35 @@ public class ShapeDetection extends OpenCvPipeline {
             Imgproc.putText(onlyFoundColorMask, "bwImage mask", new Point(5, 20), Imgproc.FONT_HERSHEY_DUPLEX, 0.5, new Scalar(255, 255, 0));
             Imgproc.putText(onlyFoundColorBlur, "blurImg mask", new Point(5, 20), Imgproc.FONT_HERSHEY_DUPLEX, 0.5, new Scalar(255, 255, 0));
             // Make borders for stacking images
-            Core.copyMakeBorder(inputFrameRGB, inputFrameRGB, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
-            Core.copyMakeBorder(croppedInputFrameRGB, croppedInputFrameRGB, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
-            Core.copyMakeBorder(onlyFoundColorMask, onlyFoundColorMask, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
-            Core.copyMakeBorder(onlyFoundColorBlur, onlyFoundColorBlur, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
-            Core.copyMakeBorder(markup, markup, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
+            //Core.copyMakeBorder(resizedInputFrame, resizedInputFrame, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
+            //Core.copyMakeBorder(croppedInputFrameRGB, croppedInputFrameRGB, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
+            //Core.copyMakeBorder(onlyFoundColorMask, onlyFoundColorMask, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
+            //Core.copyMakeBorder(onlyFoundColorBlur, onlyFoundColorBlur, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
+            //Core.copyMakeBorder(markup, markup, 1, 1, 1, 1, Core.BORDER_CONSTANT, new Scalar(255, 255, 255));
 
             // Make the top row
-            Mat outputFrameTop = new Mat();
             Core.hconcat(Arrays.asList(onlyFoundColorMask, onlyFoundColorBlur), outputFrameTop);
             // Make the bottom row
-            Mat outputFrameBottom = new Mat();
             Core.hconcat(Arrays.asList(croppedInputFrameRGB, markup), outputFrameBottom);
             // Make the output frame, combining the top and bottom rows, plus a blank space
             // I couldn't figure out how to disable the purple overlay.
-            outputFrame = new Mat();
-            Mat blankForOverlay = new Mat(76, outputFrameTop.width(), 16, new Scalar(102, 20, 68));
+            if (blankForOverlay == null) {
+                blankForOverlay = new Mat(76, outputFrameTop.width(), CV_8U3, new Scalar(102, 20, 68));
+            }
             Core.vconcat(Arrays.asList(outputFrameTop, outputFrameBottom, blankForOverlay), outputFrame);
 
             // EOCV-Simulator seems to flicker when image is black (0,0,0).
             // So, change it to (1,1,1)...
-            Mat zeros = new Mat();
             Core.inRange(outputFrame, new Scalar(0, 0, 0), new Scalar(0, 0, 0), zeros);
             outputFrame.setTo(new Scalar(1, 1, 1), zeros);
-            return outputFrame;
+
+            Imgproc.resize(outputFrame, outputFrame, pipelineSize);
         }
         else {
-            return inputFrameRGB;
+            inputFrameRGB.copyTo(outputFrame);
         }
-    }
 
-    public double xMid(){
-        if(rect != null){
-            return rect.x + (rect.width/2);
-        }
-        return 500; // Code Review: This code does nothing. rect != null is already tested.
-        //Android Studio gets upset if there's no return statement outside of an if
+        telemetry.update();
+        return outputFrame;
     }
 }


### PR DESCRIPTION
Add Config decorator for ShapeDetection, so that it can be changed from dashboard. Change access modifiers so that config-things are public static, as required. Make other things private.

Try to avoid churning OpenCV memory in the pipeline -- create the Mats and such only once. Still seeing a notice that memory is 'leaking' (garbage collected), although I'm not sure where. Could be in the operations like draw contour? Commented out the copymakeborder for this purpose.